### PR TITLE
Hide GitHub and Docs links

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,6 @@
           <div class="nav-links">
             <a href="#features" data-i18n="nav.features">Features</a>
             <a href="#install" data-i18n="nav.install">Install</a>
-            <a href="https://github.com/pingcap" target="_blank" rel="noreferrer">GitHub</a>
           </div>
           <div class="lang-switch" id="lang-switch">
             <button class="lang-btn" aria-label="Switch language" aria-expanded="false" aria-haspopup="true">
@@ -355,13 +354,9 @@
       <footer class="footer">
         <div class="footer-inner">
           <div class="footer-nav">
-            <a href="https://github.com/pingcap" target="_blank" rel="noreferrer">GitHub</a>
-            <span class="footer-separator">&middot;</span>
             <a href="#install" data-i18n="footer.install">Install</a>
             <span class="footer-separator">&middot;</span>
             <a href="#features" data-i18n="footer.features">Features</a>
-            <span class="footer-separator">&middot;</span>
-            <a href="#top" data-i18n="footer.docs">Docs</a>
           </div>
           <p class="copyright" data-i18n="footer.tagline">Structured memory for OpenClaw agents.</p>
           <p class="disclaimer" data-i18n="footer.license">Apache-2.0 License</p>


### PR DESCRIPTION
## Summary

- Remove GitHub link from top navigation bar
- Remove GitHub and Docs links from footer

## Test plan

- [ ] Nav bar only shows Features and Install links
- [ ] Footer only shows Install and Features links
- [ ] No broken layout from removed elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)