### PR TITLE
Add PostHog analytics with event tracking

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,160 @@
+/* ── PostHog Event Tracking ── */
+
+function ph(event, props) {
+  if (typeof posthog !== "undefined" && posthog.capture) {
+    posthog.capture(event, props);
+  }
+}
+
+/* ── Theme toggle ── */
+document.getElementById("theme-toggle")?.addEventListener("click", () => {
+  // read after toggle (main.js toggles first since it loads before this)
+  requestAnimationFrame(() => {
+    ph("theme_toggled", {
+      theme: document.documentElement.dataset.theme || "dark",
+    });
+  });
+});
+
+/* ── Install command copy ── */
+document.querySelectorAll("[data-copy-button]").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    const location = btn.dataset.copyButton === "hero-skill" ? "hero" : "cta";
+    // delay slightly so we can check the is-copied class set by main.js
+    setTimeout(() => {
+      ph("install_command_copied", {
+        location,
+        success: btn.classList.contains("is-copied"),
+      });
+    }, 100);
+  });
+});
+
+/* ── Language changed ── */
+document.querySelectorAll("[data-lang-option]").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    const prevLang = document.documentElement.lang || "en";
+    // i18n.js updates lang synchronously on click
+    requestAnimationFrame(() => {
+      const newLang = document.documentElement.lang || "en";
+      ph("language_changed", {
+        from: prevLang,
+        to: newLang,
+        language: newLang,
+      });
+    });
+  });
+});
+
+/* ── Nav link clicks ── */
+document.querySelectorAll(".nav-links a").forEach((a) => {
+  a.addEventListener("click", () => {
+    ph("nav_clicked", {
+      target: a.getAttribute("href")?.replace("#", "") || a.textContent.trim(),
+    });
+  });
+});
+
+/* ── Footer link clicks ── */
+document.querySelectorAll(".footer-nav a").forEach((a) => {
+  a.addEventListener("click", () => {
+    ph("footer_clicked", {
+      target: a.getAttribute("href")?.replace("#", "") || a.textContent.trim(),
+    });
+  });
+});
+
+/* ── Section viewed (scroll tracking) ── */
+const sectionMap = {
+  "section-how": "features",
+  "section-inspectable": "inspectable_memory",
+  "section-hood": "under_the_hood",
+  "section-compare": "comparison",
+  "section-cta": "cta_install",
+};
+
+if ("IntersectionObserver" in window) {
+  const viewedSections = new Set();
+  const sectionObserver = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        const el = entry.target;
+        for (const [cls, name] of Object.entries(sectionMap)) {
+          if (el.classList.contains(cls) && !viewedSections.has(name)) {
+            viewedSections.add(name);
+            ph("section_viewed", { section: name });
+            sectionObserver.unobserve(el);
+            break;
+          }
+        }
+      });
+    },
+    { threshold: 0.25 }
+  );
+
+  for (const cls of Object.keys(sectionMap)) {
+    const el = document.querySelector("." + cls);
+    if (el) sectionObserver.observe(el);
+  }
+}
+
+/* ── Hero viewed (track if user actually sees the hero content) ── */
+const heroEl = document.querySelector(".hero");
+if (heroEl && "IntersectionObserver" in window) {
+  let heroTracked = false;
+  const heroObs = new IntersectionObserver(
+    (entries) => {
+      if (heroTracked) return;
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          heroTracked = true;
+          ph("section_viewed", { section: "hero" });
+          heroObs.disconnect();
+        }
+      });
+    },
+    { threshold: 0.5 }
+  );
+  heroObs.observe(heroEl);
+}
+
+/* ── Scroll depth tracking ── */
+(() => {
+  const milestones = [25, 50, 75, 100];
+  const reached = new Set();
+
+  function checkDepth() {
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    if (docHeight <= 0) return;
+    const pct = Math.round((scrollTop / docHeight) * 100);
+
+    for (const m of milestones) {
+      if (pct >= m && !reached.has(m)) {
+        reached.add(m);
+        ph("scroll_depth", { percent: m });
+      }
+    }
+  }
+
+  let ticking = false;
+  window.addEventListener("scroll", () => {
+    if (!ticking) {
+      ticking = true;
+      requestAnimationFrame(() => {
+        checkDepth();
+        ticking = false;
+      });
+    }
+  }, { passive: true });
+})();
+
+/* ── Initial page properties ── */
+requestAnimationFrame(() => {
+  const i18n = window.__i18n;
+  posthog?.register?.({
+    initial_theme: document.documentElement.dataset.theme || "dark",
+    initial_language: i18n ? i18n.currentLang() : document.documentElement.lang || "en",
+  });
+});

--- a/index.html
+++ b/index.html
@@ -26,6 +26,13 @@
     <link href="https://api.fontshare.com/v2/css?f[]=clash-display@700,600,500&f[]=satoshi@400,500,700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/styles.css" />
     <script>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('phc_DhFvjtt8ZoDdZ2H4jqM1PlVTGtwr5fQKFBldLm80xZU', {
+          api_host: 'https://us.i.posthog.com',
+          defaults: '2026-01-30'
+      })
+    </script>
+    <script>
       (() => {
         const key = 'cm-theme';
         const saved = localStorage.getItem(key);
@@ -367,5 +374,6 @@
     <p class="sr-only" data-copy-feedback aria-live="polite"></p>
     <script type="module" src="/i18n.js"></script>
     <script type="module" src="/main.js"></script>
+    <script type="module" src="/analytics.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Add PostHog SDK snippet to `<head>`
- Create `analytics.js` with comprehensive event tracking:
  - `section_viewed` — fires once per section when scrolled into view (threshold 25%)
  - `scroll_depth` — fires at 25/50/75/100% scroll milestones
  - `install_command_copied` — tracks hero vs CTA location and copy success
  - `theme_toggled` — captures new theme value
  - `language_changed` — captures from/to language
  - `nav_clicked` / `footer_clicked` — link click tracking
- Register `initial_theme` and `initial_language` as super properties

## Test plan

- [ ] Open PostHog live events and verify `$pageview` fires on load
- [ ] Scroll down — verify `section_viewed` events fire for each section
- [ ] Scroll to bottom — verify `scroll_depth` 25/50/75/100 events
- [ ] Click copy button in hero — verify `install_command_copied` with `location: "hero"`
- [ ] Click copy button in CTA — verify `install_command_copied` with `location: "cta"`
- [ ] Toggle theme — verify `theme_toggled` event
- [ ] Switch language — verify `language_changed` event with from/to
- [ ] Click nav links — verify `nav_clicked` events
- [ ] Verify super properties `initial_theme` and `initial_language` are present on all events

🤖 Generated with [Claude Code](https://claude.com/claude-code)