### PR TITLE
Switch display font to General Sans

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
     <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
     <link rel="icon" href="/favicon-16.png" sizes="16x16" type="image/png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <!-- Fonts: Clash Display + Satoshi from Fontshare (same as OpenClaw) -->
+    <!-- Fonts: General Sans + Satoshi from Fontshare -->
     <link rel="preconnect" href="https://api.fontshare.com" />
     <link rel="preconnect" href="https://cdn.fontshare.com" crossorigin />
-    <link href="https://api.fontshare.com/v2/css?f[]=clash-display@700,600,500&f[]=satoshi@400,500,700&display=swap" rel="stylesheet" />
+    <link href="https://api.fontshare.com/v2/css?f[]=general-sans@700,600,500&f[]=satoshi@400,500,700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/styles.css" />
     <script>
       !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);

--- a/styles.css
+++ b/styles.css
@@ -51,7 +51,7 @@
   --logo-glow: rgba(224, 71, 90, 0.35);
   --logo-glow-hover: rgba(45, 212, 184, 0.5);
 
-  --font-display: "Clash Display", system-ui, sans-serif;
+  --font-display: "General Sans", system-ui, sans-serif;
   --font-body: "Satoshi", system-ui, sans-serif;
   --font-mono: "SF Mono", "Fira Code", "JetBrains Mono", monospace;
 


### PR DESCRIPTION
## Summary
- Replace Clash Display with General Sans (Fontshare) for all headings
- Better readability for section headers while keeping a modern, clean aesthetic
- Pairs well with existing Satoshi body font

Closes #14

## Test plan
- [x] Verify all section headers render in General Sans
- [x] Check heading readability across hero, How It Works, Inspectable, Under the Hood, CTA
- [x] Confirm font loads correctly (Fontshare CDN)
- [x] Test dark/light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)