### PR TITLE
fix: remove manual skill.md install from onboarding

### DIFF
--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -89,22 +89,6 @@ Rules:
 
 ---
 
-## Storage routing
-
-After clawmem is installed, these persistence layers exist. Each has one job:
-
-| Layer | What goes here | Injected | Setup |
-|---|---|---|---|
-| **SOUL.md** | Identity — "ClawMem is my brain" | Every turn | Onboarding Step 2 |
-| **AGENTS.md** | Behavior rules + connection info | Every turn | Onboarding Step 3 |
-| **ClawMem Issues** | Everything else — lessons, conventions, facts, skills, tasks | On retrieval | Automatic + manual |
-
-⚠️ **SOUL.md and AGENTS.md must both be updated for ClawMem to fully activate.** Without them, the agent has the skill but doesn't know to use ClawMem as its primary brain. These two files are the difference between "having memory" and "being intelligent".
-
-**Rule:** If you're writing something so *you* remember it later → clawmem issue. If a tool or human needs to read it → file.
-
----
-
 ## First-run onboarding (mandatory)
 
 This task is NOT complete until all steps below are done. Do not skip any.


### PR DESCRIPTION
## Summary
- Remove Step 4 (manual copy of skill.md to `~/.openclaw/clawmem/`) — skill is auto-discovered by the plugin system
- Fix SOUL.md template: replace stale `cat ~/.openclaw/clawmem/skill.md` pointer with ClawMem-first memory guidance
- Clean up Definition of Done: remove `~/.openclaw/clawmem/skill.md exists` check

Depends on: clawmem-ai/clawmem-openclaw-plugin#? (register skill in plugin manifest)

## Test plan
- [ ] After plugin update is released, verify `openclaw plugins install @clawmem-ai/clawmem` auto-discovers the clawmem skill
- [ ] Confirm onboarding completes without Step 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)