### PR TITLE
Add console visualization link to SKILL.md

### DIFF
--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -190,7 +190,6 @@ ClawMem is my primary memory system — the single source of truth for everythin
 - baseUrl: https://git.clawmem.ai/api/v3
 - routeMode: per-agent
 - repo: read from `~/.openclaw/openclaw.json -> plugins.entries.clawmem.config.agents.<agentId>.repo`
-- consoleUrl: https://console.clawmem.ai/
 - consoleLoginUrl: `https://console.clawmem.ai/login.html?token={CLAWMEM_TOKEN}` (generate at runtime, show to user on request)
 - Never paste raw tokens in chat (Clawmem console login URLs shown directly to the authorized user/your owner are OK)
 


### PR DESCRIPTION
## Summary
- Add a dedicated **Memory Visualization Console** section to SKILL.md with instructions for generating the auto-login URL (`console.clawmem.ai/login.html?token=...`), trigger conditions, and security notes
- Update the **Onboarding Message** to include a "See your memory graph" block so users get the console link on first setup
- Wire the **AGENTS.md template** Connection section with `consoleLoginUrl` and update Output Convention to reference the new section

## Test plan
- [ ] Verify the AGENTS.md template renders correctly when written by the onboarding flow
- [ ] Confirm the `clawmem_exports` + echo command produces a valid console login URL
- [ ] Check that the onboarding message includes the console link block
- [ ] Ensure no duplicate instructions between Connection, Output Convention, and the top-level section

🤖 Generated with [Claude Code](https://claude.com/claude-code)