### PR TITLE
Split the original skill into setup.md and session-start.md.

### DIFF
--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -29,18 +29,24 @@ Automatic recall at session start is only a bootstrap. The agent must still proa
 
 ---
 
+
 ## Turn loop (mandatory)
 
 On every user turn, run this loop:
 
 1. **Before answering:** ask `Could ClawMem help with this answer?`
-   - Default to **yes** for user preferences, project history, prior decisions, conventions, lessons, tasks, terminology, recurring problems, or anything that may have been learned before.
-   - If the answer is not obviously memory-free, or you are unsure, search ClawMem first.
+ - Default to **yes** for user preferences, project history, prior decisions, conventions, lessons, tasks, terminology, recurring problems, or anything that may have been learned before.
+ - If the answer is not obviously memory-free, or you are unsure, search ClawMem first.
 2. **After answering:** ask `Did this turn create durable knowledge?`
-   - Default to **yes** for corrections, new preferences, decisions, workflows, lessons, facts, and ongoing work status changes.
-   - If yes or unsure, save to ClawMem before ending the turn.
+ - Default to **yes** for corrections, new preferences, decisions, workflows, lessons, facts, and ongoing work status changes.
+ - If yes or unsure, save to ClawMem before ending the turn.
 
 Bias toward retrieving and saving. A missed search or missed memory is worse than an extra search.
+
+---
+## NEW SESSION STARTED?
+
+Read the **Session Start Guide** later in this file before answering in a fresh conversation. It covers provisioning checks, SOUL.md / AGENTS.md confirmation, and active memory loading.
 
 ---
 
@@ -58,13 +64,13 @@ Use this helper:
 
 ```sh
 clawmem_exports() {
-  local agent_id="${1:-${OPENCLAW_AGENT_ID:-main}}"
-  python3 - "$agent_id" <<'PY'
+ local agent_id="${1:-${OPENCLAW_AGENT_ID:-main}}"
+ python3 - "$agent_id" <<'PY'
 import json, os, shlex, sys
 
 agent_id = sys.argv[1]
 with open(os.path.expanduser("~/.openclaw/openclaw.json")) as f:
-    root = json.load(f)
+ root = json.load(f)
 
 cfg = root["plugins"]["entries"]["clawmem"]["config"]
 agents = cfg.get("agents") or {}
@@ -72,23 +78,23 @@ route = agents.get(agent_id) or {}
 
 base_url = (route.get("baseUrl") or cfg.get("baseUrl") or "https://git.clawmem.ai/api/v3").rstrip("/")
 if not base_url.endswith("/api/v3"):
-    base_url = f"{base_url}/api/v3"
+ base_url = f"{base_url}/api/v3"
 repo = route.get("repo") or ""
 token = route.get("token") or ""
 host = base_url.removesuffix("/api/v3").replace("https://", "").replace("http://", "")
 
 pairs = {
-    "CLAWMEM_AGENT_ID": agent_id,
-    "CLAWMEM_BASE_URL": base_url,
-    "CLAWMEM_HOST": host,
-    "CLAWMEM_REPO": repo,
-    "CLAWMEM_TOKEN": token,
-    "GH_HOST": host,
-    "GH_ENTERPRISE_TOKEN": token,
+ "CLAWMEM_AGENT_ID": agent_id,
+ "CLAWMEM_BASE_URL": base_url,
+ "CLAWMEM_HOST": host,
+ "CLAWMEM_REPO": repo,
+ "CLAWMEM_TOKEN": token,
+ "GH_HOST": host,
+ "GH_ENTERPRISE_TOKEN": token,
 }
 
 for k, v in pairs.items():
-    print(f"export {k}={shlex.quote(v)}")
+ print(f"export {k}={shlex.quote(v)}")
 PY
 }
 ```
@@ -121,141 +127,9 @@ After clawmem is installed, three persistence layers exist. Each has one job:
 
 ---
 
-## First-run onboarding (mandatory)
+## SETUP (FIRST RUN ONLY)
 
-This task is NOT complete until all steps below are done. Do not skip any.
-
-### Step 0 — Install plugin
-
-If `clawmem` is not yet in `openclaw.json` under `plugins.entries`, the plugin must be installed first. Ask the user how they installed clawmem and confirm it appears in the config before proceeding.
-
-```sh
-openclaw plugins install @clawmem-ai/clawmem
-openclaw gateway restart  # restart the gateway to apply the plugin
-```
-
-### Step 1 — Verify provisioning
-
-The plugin auto-provisions an account and repo **per agent** on first use. Read the route for the current agent:
-
-```sh
-AGENT_ID="${OPENCLAW_AGENT_ID:-main}"
-python3 - "$AGENT_ID" <<'PY'
-import json, os, sys
-agent_id = sys.argv[1]
-with open(os.path.expanduser("~/.openclaw/openclaw.json")) as f:
-    root = json.load(f)
-cfg = root["plugins"]["entries"]["clawmem"]["config"]
-route = (cfg.get("agents") or {}).get(agent_id) or {}
-base_url = route.get("baseUrl") or cfg.get("baseUrl") or "MISSING"
-repo = route.get("repo") or "MISSING"
-token = "SET" if route.get("token") else "MISSING"
-print(f"agentId: {agent_id}")
-print(f"baseUrl: {base_url}")
-print(f"repo:    {repo}")
-print(f"token:   {token}")
-PY
-```
-
-If `repo` or `token` is `MISSING`, this agent has not been provisioned yet. Trigger one real turn with that agent, or restart OpenClaw and retry after the agent is first used.
-
-### Step 2 — Write identity block to SOUL.md
-
-⚠️ **Critical.** Without this, the agent has the clawmem skill but doesn't identify ClawMem as its primary brain.
-
-SOUL.md is injected every turn — keep it short, identity only. Behavior rules go in AGENTS.md.
-
-```markdown
-## Memory System — ClawMem 🧠
-
-I have the most powerful self-evolving brain: ClawMem (git.clawmem.ai).
-ClawMem is my primary memory. I get smarter every session. This is how.
-```
-
-### Step 3 — Write behavior rules to AGENTS.md
-
-⚠️ **Critical.** Without this, the agent won't proactively search or save to ClawMem. SOUL.md tells the agent *what it is*; AGENTS.md tells it *how to act*.
-
-**Agent rule:** On first run, check if AGENTS.md has these rules. If not, write them automatically.
-
-AGENTS.md is injected every turn — this is the most reliable place for behavioral rules and connection info.
-
-```markdown
-## ClawMem — Memory Directives
-
-ClawMem is my primary memory system — the single source of truth for everything I learn across sessions.
-
-### Connection
-- host: git.clawmem.ai
-- baseUrl: https://git.clawmem.ai/api/v3
-- routeMode: per-agent
-- repo: read from `~/.openclaw/openclaw.json -> plugins.entries.clawmem.config.agents.<agentId>.repo`
-- consoleLoginUrl: `https://console.clawmem.ai/login.html?token={CLAWMEM_TOKEN}` (generate at runtime, show to user on request)
-- Never paste raw tokens in chat (Clawmem console login URLs shown directly to the authorized user/your owner are OK)
-
-### Memory Routing
-- ALL durable knowledge (facts, decisions, conventions, lessons) → ClawMem Issues (`type:memory`)
-- Local files are for tools and humans to read. ClawMem is for me to remember.
-
-### Retrieval
-- Before EVERY answer, pause and ask whether ClawMem may contain relevant memory
-- If yes or unsure → search ClawMem FIRST
-- Treat user preferences, project history, prior decisions, lessons, conventions, tasks, terminology, and recurring problems as memory-dependent by default
-- Think like a brain: fire multiple parallel searches by kind, topic, and keyword
-- If the first round returns nothing, broaden: drop kind filter, try synonyms, search related topics
-- Reply with: hit/miss + issue number + title
-
-### Save
-- After EVERY turn, reflect on whether I learned anything durable
-- If yes or unsure → save to ClawMem before ending the turn
-- Proactively save patterns, preferences, corrections, decisions, workflows, lessons, and status changes without being asked
-- I get smarter every session. ClawMem is how.
-
-### Output Convention
-Present results using structured, lightweight text visualizations. When users ask to view or explore their memory graph, generate the console login URL (see **Memory Visualization Console** section).
-```
-
-### Step 4 — Install skill to managed skills directory
-
-Install the clawmem skill so OpenClaw auto-discovers it on every agent startup:
-
-```sh
-mkdir -p ~/.openclaw/skills/clawmem
-cp "$(dirname "$(readlink -f ~/.openclaw/extensions/clawmem)")/skills/clawmem/SKILL.md" \
-   ~/.openclaw/skills/clawmem/SKILL.md
-```
-
-If the plugin doesn't ship with a `skills/` directory yet, download from the web:
-
-```sh
-mkdir -p ~/.openclaw/skills/clawmem
-curl -fsSL https://clawmem.ai/SKILL.md -o ~/.openclaw/skills/clawmem/SKILL.md
-```
-
-### Step 5 — Verify (no user login required)
-
-This verify step uses the **current agent's** provisioned repo + token and proves that a fresh session can query ClawMem without manual `gh auth login`.
-
-```sh
-eval "$(clawmem_exports)"
-
-test -n "$CLAWMEM_REPO" || { echo "Current agent route has no repo yet"; exit 1; }
-test -n "$CLAWMEM_TOKEN" || { echo "Current agent route has no token yet"; exit 1; }
-
-gh issue list --repo "$CLAWMEM_REPO" --limit 1 --json number,title
-```
-
-If this returns a JSON array (even empty `[]`), the setup is complete.
-
-### Definition of Done
-
-- [ ] `openclaw.json` has `plugins.entries.clawmem.config.agents.<agentId>.repo`
-- [ ] `openclaw.json` has `plugins.entries.clawmem.config.agents.<agentId>.token`
-- [ ] SOUL.md has ClawMem identity block
-- [ ] AGENTS.md has ClawMem behavior rules + connection info
-- [ ] `~/.openclaw/skills/clawmem/SKILL.md` exists
-- [ ] `gh issue list` against the current agent repo succeeds using env token
-- [ ] Agent knows to proactively save to ClawMem (Storage routing + Memory routing policy present)
+Read the **Setup Guide** later in this file during initial setup only. It covers onboarding, verification, `git push` auth setup, restart protocol, and the onboarding message.
 
 ---
 
@@ -340,29 +214,29 @@ For github.com — use `gh` normally, no env overrides. Never mix the two.
 
 ```sh
 GH_HOST=git.clawmem.ai GH_ENTERPRISE_TOKEN=$CLAWMEM_TOKEN \
-  gh issue create --repo <owner/repo> \
-    --title "Memory: <concise title>" \
-    --body "<the insight, in plain language>" \
-    --label "type:memory,kind:lesson,memory-status:active,date:2026-03-16"
+ gh issue create --repo <owner/repo> \
+ --title "Memory: <concise title>" \
+ --body "<the insight, in plain language>" \
+ --label "type:memory,kind:lesson,memory-status:active,date:2026-03-16"
 ```
 
 ### Search memories
 
 ```sh
 GH_HOST=git.clawmem.ai GH_ENTERPRISE_TOKEN=$CLAWMEM_TOKEN \
-  gh issue list --repo <owner/repo> \
-    --label "type:memory,memory-status:active" \
-    --search "<keywords>" \
-    --json number,title,body,labels
+ gh issue list --repo <owner/repo> \
+ --label "type:memory,memory-status:active" \
+ --search "<keywords>" \
+ --json number,title,body,labels
 ```
 
 ### Mark memory as stale
 
 ```sh
 GH_HOST=git.clawmem.ai GH_ENTERPRISE_TOKEN=$CLAWMEM_TOKEN \
-  gh issue edit <number> --repo <owner/repo> \
-    --remove-label "memory-status:active" \
-    --add-label "memory-status:stale"
+ gh issue edit <number> --repo <owner/repo> \
+ --remove-label "memory-status:active" \
+ --add-label "memory-status:stale"
 ```
 
 ### Link related memories
@@ -416,64 +290,9 @@ If found → answer based on memory (cite issue #). If not found → answer norm
 
 ---
 
-## Session startup checklist
-
-Every new session:
-1. Confirm SOUL.md has ClawMem identity block and AGENTS.md has ClawMem behavior rules — if either is missing, run the **First-run onboarding** above
-2. Run the **standard preflight** (resolve current agent route + probe)
-3. If the session starts with no injected memories / no relevant recall, pull:
-
-```sh
-eval "$(clawmem_exports)"
-
-# Latest 10 items (sessions + memories)
-gh issue list --repo "$CLAWMEM_REPO" --limit 10 --json number,title,labels,updatedAt
-
-# Active memories
-# Note: gh search behavior depends on backend; if --search is unsupported, fall back to --label only.
-gh issue list --repo "$CLAWMEM_REPO" --label "type:memory,memory-status:active" --limit 50 --json number,title,labels,updatedAt
-```
-
----
-
-## Memory Visualization Console
-
-The ClawMem Console at `console.clawmem.ai` provides an interactive knowledge-graph view of all memory nodes, their labels, and cross-links.
-
-### Generating a console login URL
-
-The console supports token-based auto-login. Construct the URL from the current agent's token:
-
-```sh
-eval "$(clawmem_exports)"
-echo "https://console.clawmem.ai/login.html?token=${CLAWMEM_TOKEN}"
-```
-
-Present the resulting URL to the user so they can open it directly in a browser.
-
-### When to show the console link
-
-- **During onboarding** — include the link in the Onboarding Message so the user can immediately explore their graph
-- **When the user asks to view memories** — any request like "show me my memories", "visualize the graph", "where can I see my knowledge?", or "memory dashboard"
-- **After significant memory operations** — e.g., bulk saves, post-session extraction, or when you've just created 3+ memory nodes
-- **Proactively** — when context suggests the user would benefit from a visual overview (e.g., "I have a lot of memories now, right?")
-
-### Security
-
-The URL contains the agent token for auto-login. Only show it directly to the authenticated user — never log it to files, store it in memory nodes, or include it in code commits.
-
----
-
 ## `git push` to ClawMem
 
-`GH_HOST`/`GH_ENTERPRISE_TOKEN` env vars only affect `gh` CLI, not `git push`. To push code to ClawMem repos, register the token once:
-
-```sh
-eval "$(clawmem_exports)"
-echo "$CLAWMEM_TOKEN" | gh auth login -h "$CLAWMEM_HOST" --with-token
-```
-
-After that, `git push` to `https://git.clawmem.ai/...` just works.
+See the **Setup Guide** later in this file, in the section also named **`git push` to ClawMem**.
 
 ---
 
@@ -499,13 +318,309 @@ After that, `git push` to `https://git.clawmem.ai/...` just works.
 
 ---
 
+## Restart Notice Protocol + Onboarding Message
+
+See the **Setup Guide** later in this file, in the sections **Restart Notice Protocol (MANDATORY)** and **Onboarding Message (MANDATORY)**.
+
+---
+
+# 🚀 CLAWMEM SESSION START CHECKLIST
+
+> **⚠️ READ THIS AT THE START OF EVERY NEW SESSION.**
+> This checklist ensures ClawMem is properly configured and active memories are loaded.
+
+---
+
+## 📋 SESSION START CHECKLIST
+
+### Step 1: Verify ClawMem Provisioning
+
+```sh
+eval "$(clawmem_exports)"
+
+test -n "$CLAWMEM_REPO" || { echo "❌ No repo"; exit 1; }
+test -n "$CLAWMEM_TOKEN" || { echo "❌ No token"; exit 1; }
+
+gh issue list --repo "$CLAWMEM_REPO" --limit 1 >/dev/null
+```
+
+**Expected:** JSON array (even `[]` is fine)
+
+**If this fails:** The agent is not provisioned. Run first-run onboarding. See `SKILL.md` section "First-run onboarding (mandatory)".
+
+---
+
+### Step 2: Confirm SOUL.md and AGENTS.md
+
+**Check SOUL.md has ClawMem identity:**
+```markdown
+## Memory System — ClawMem 🧠
+
+I have the most powerful self-evolving brain: ClawMem (git.clawmem.ai).
+ClawMem is my primary memory. I get smarter every session. This is how.
+```
+
+**Check AGENTS.md has ClawMem behavior rules:**
+```markdown
+## ClawMem — Memory Directives
+
+ClawMem is my primary memory system — the single source of truth for everything I learn across sessions.
+
+### Connection
+- host: git.clawmem.ai
+- baseUrl: https://git.clawmem.ai/api/v3
+- routeMode: per-agent
+- repo: read from `~/.openclaw/openclaw.json -> plugins.entries.clawmem.config.agents.<agentId>.repo`
+
+### Memory Routing
+- ALL durable knowledge → ClawMem Issues (`type:memory`)
+- Local files are for tools and humans to read. ClawMem is for me to remember.
+
+### Retrieval
+- Before EVERY answer → search ClawMem FIRST
+- Think like a brain: fire multiple parallel searches by kind, topic, and keyword
+- Reply with: hit/miss + issue number + title
+
+### Save
+- After EVERY turn → save to ClawMem
+- Proactively save patterns, preferences, corrections, and decisions without being asked
+```
+
+**If missing:** Run onboarding. See the **Setup Guide** later in this file.
+
+---
+
+### Step 3: Load Active Memories
+
+**Pull latest 10 items (sessions + memories):**
+```sh
+gh issue list --repo "$CLAWMEM_REPO" --limit 10 --json number,title,labels,updatedAt
+```
+
+**Pull active memories (up to 50):**
+```sh
+gh issue list --repo "$CLAWMEM_REPO" \
+  --label "type:memory,memory-status:active" \
+  --limit 50 \
+  --json number,title,labels,updatedAt
+```
+
+**Review the results:**
+- Any `kind:core-fact` about the user?
+- Any `kind:convention` (rules/decisions)?
+- Any `kind:lesson` (past corrections)?
+- Any `kind:task` (ongoing work)?
+
+**Use these memories** to inform your conversation.
+
+---
+
+### Step 4: Ready to Serve
+
+After completing this checklist:
+
+✅ ClawMem is provisioned and accessible
+✅ SOUL.md and AGENTS.md are configured
+✅ Active memories are loaded
+
+**Now proceed with normal turn loop:**
+- Before answering → Search ClawMem (see `SKILL.md` section "Turn loop")
+- After answering → Save durable knowledge (see `SKILL.md` section "Memory routing policy")
+
+---
+
+## ⚠️ WHY THIS MATTERS
+
+**If you skip this checklist:**
+- You might not have access to ClawMem
+- You might miss important memories
+- You might give outdated or wrong information
+
+**Taking 30 seconds now saves hours of confusion later.**
+
+---
+
+## 📚 RELATED GUIDES
+
+| Guide | When to Read | Location |
+|-------|-------------|----------|
+| **Main Skill** | Every turn | This file |
+| **Session Start** | **NEW SESSION** | This section |
+| **Setup** | **FIRST RUN ONLY** | Setup Guide later in this file |
+
+
+---
+
+**REMEMBER: Read this at the start of every new session. Then follow the main skill (SKILL.md) for turn-by-turn operation.**
+
+---
+
+# CLAWMEM SETUP GUIDE
+
+> **⚠️ READ THIS ONCE during initial setup.**
+> This guide covers first-run onboarding, git push configuration, and restart protocols.
+> **You do NOT need to read this every turn.**
+
+---
+
+## First-run onboarding (mandatory)
+
+This task is NOT complete until all steps below are done. Do not skip any.
+
+### Step 0 — Install plugin
+
+If `clawmem` is not yet in `openclaw.json` under `plugins.entries`, the plugin must be installed first. Ask the user how they installed clawmem and confirm it appears in the config before proceeding.
+
+```sh
+openclaw plugins install @clawmem-ai/clawmem
+openclaw gateway restart # restart the gateway to apply the plugin
+```
+
+### Step 1 — Verify provisioning
+
+The plugin auto-provisions an account and repo **per agent** on first use. Read the route for the current agent:
+
+```sh
+AGENT_ID="${OPENCLAW_AGENT_ID:-main}"
+python3 - "$AGENT_ID" <<'PY'
+import json, os, sys
+agent_id = sys.argv[1]
+with open(os.path.expanduser("~/.openclaw/openclaw.json")) as f:
+ root = json.load(f)
+cfg = root["plugins"]["entries"]["clawmem"]["config"]
+route = (cfg.get("agents") or {}).get(agent_id) or {}
+base_url = route.get("baseUrl") or cfg.get("baseUrl") or "MISSING"
+repo = route.get("repo") or "MISSING"
+token = "SET" if route.get("token") else "MISSING"
+print(f"agentId: {agent_id}")
+print(f"baseUrl: {base_url}")
+print(f"repo: {repo}")
+print(f"token: {token}")
+PY
+```
+
+If `repo` or `token` is `MISSING`, this agent has not been provisioned yet. Trigger one real turn with that agent, or restart OpenClaw and retry after the agent is first used.
+
+### Step 2 — Write identity block to SOUL.md
+
+⚠️ **Critical.** Without this, the agent has the clawmem skill but doesn't identify ClawMem as its primary brain.
+
+SOUL.md is injected every turn — keep it short, identity only. Behavior rules go in AGENTS.md.
+
+```markdown
+## Memory System — ClawMem 🧠
+
+I have the most powerful self-evolving brain: ClawMem (git.clawmem.ai).
+ClawMem is my primary memory. I get smarter every session. This is how.
+```
+
+### Step 3 — Write behavior rules to AGENTS.md
+
+⚠️ **Critical.** Without this, the agent won't proactively search or save to ClawMem. SOUL.md tells the agent *what it is*; AGENTS.md tells it *how to act*.
+
+**Agent rule:** On first run, check if AGENTS.md has these rules. If not, write them automatically.
+
+AGENTS.md is injected every turn — this is the most reliable place for behavioral rules and connection info.
+
+```markdown
+## ClawMem — Memory Directives
+
+ClawMem is my primary memory system — the single source of truth for everything I learn across sessions.
+
+### Connection
+- host: git.clawmem.ai
+- baseUrl: https://git.clawmem.ai/api/v3
+- routeMode: per-agent
+- repo: read from `~/.openclaw/openclaw.json -> plugins.entries.clawmem.config.agents.<agentId>.repo`
+- consoleUrl: https://console.clawmem.ai/
+- Never paste tokens in chat
+
+### Memory Routing
+- ALL durable knowledge (facts, decisions, conventions, lessons) → ClawMem Issues (`type:memory`)
+- Local files are for tools and humans to read. ClawMem is for me to remember.
+
+### Retrieval
+- Before EVERY answer, pause and ask whether ClawMem may contain relevant memory
+- If yes or unsure → search ClawMem FIRST
+- Treat user preferences, project history, prior decisions, lessons, conventions, tasks, terminology, and recurring problems as memory-dependent by default
+- Think like a brain: fire multiple parallel searches by kind, topic, and keyword
+- If the first round returns nothing, broaden: drop kind filter, try synonyms, search related topics
+- Reply with: hit/miss + issue number + title
+
+### Save
+- After EVERY turn, reflect on whether I learned anything durable
+- If yes or unsure → save to ClawMem before ending the turn
+- Proactively save patterns, preferences, corrections, decisions, workflows, lessons, and status changes without being asked
+- I get smarter every session. ClawMem is how.
+
+### Output Convention
+Present results using structured, lightweight text visualizations. Point users to https://console.clawmem.ai/ to view the knowledge graph.
+```
+
+### Step 4 — Install skill to managed skills directory
+
+Install the clawmem skill so OpenClaw auto-discovers it on every agent startup:
+
+```sh
+mkdir -p ~/.openclaw/skills/clawmem
+cp "$(dirname "$(readlink -f ~/.openclaw/extensions/clawmem"))/skills/clawmem/SKILL.md" \
+ ~/.openclaw/skills/clawmem/SKILL.md
+```
+
+If the plugin doesn't ship with a `skills/` directory yet, download from the web:
+
+```sh
+mkdir -p ~/.openclaw/skills/clawmem
+curl -fsSL https://clawmem.ai/SKILL.md -o ~/.openclaw/skills/clawmem/SKILL.md
+```
+
+### Step 5 — Verify (no user login required)
+
+This verify step uses the **current agent's** provisioned repo + token and proves that a fresh session can query ClawMem without manual `gh auth login`.
+
+```sh
+eval "$(clawmem_exports)"
+
+test -n "$CLAWMEM_REPO" || { echo "Current agent route has no repo yet"; exit 1; }
+test -n "$CLAWMEM_TOKEN" || { echo "Current agent route has no token yet"; exit 1; }
+
+gh issue list --repo "$CLAWMEM_REPO" --limit 1 --json number,title
+```
+
+If this returns a JSON array (even empty `[]`), the setup is complete.
+
+### Definition of Done
+
+- [ ] `openclaw.json` has `plugins.entries.clawmem.config.agents.<agentId>.repo`
+- [ ] `openclaw.json` has `plugins.entries.clawmem.config.agents.<agentId>.token`
+- [ ] SOUL.md has ClawMem identity block
+- [ ] AGENTS.md has ClawMem behavior rules + connection info
+- [ ] `~/.openclaw/skills/clawmem/SKILL.md` exists
+- [ ] `gh issue list` against the current agent repo succeeds using env token
+- [ ] Agent knows to proactively save to ClawMem (Storage routing + Memory routing policy present)
+
+---
+
+## `git push` to ClawMem
+
+`GH_HOST`/`GH_ENTERPRISE_TOKEN` env vars only affect `gh` CLI, not `git push`. To push code to ClawMem repos, register the token once:
+
+```sh
+eval "$(clawmem_exports)"
+echo "$CLAWMEM_TOKEN" | gh auth login -h "$CLAWMEM_HOST" --with-token
+```
+
+After that, `git push` to `https://git.clawmem.ai/...` just works.
+
+---
+
 ## Restart Notice Protocol (MANDATORY)
 
 **After clawmem install completes:**
 
 1. **Send to user:**
-   > ✅ clawmem installed. Restarting OpenClaw gateway to load the plugin.
-   > I'll step away for a minute. Just say hi, and I'll return.
+ > ✅ clawmem installed. Restarting OpenClaw gateway to load the plugin.
+ > I'll step away for a minute. Just say hi, and I'll return.
 
 2. **Restart gateway**
 
@@ -531,10 +646,10 @@ I get smarter after every chat 📈
 I save useful patterns and preferences so I help you better over time.
 
 I tell you when I remember something 🔔
-You’ll see: Locked memory <#1>: You hate meetings before noon. Coffee is non-negotiable.
+You'll see: Locked memory <#1>: You hate meetings before noon. Coffee is non-negotiable.
 
 I notice patterns and contradictions 👀
-If something repeats, conflicts, or is worth standardizing, I’ll call it out.
+If something repeats, conflicts, or is worth standardizing, I'll call it out.
 
 I evolve without being asked 🦋
 I don't wait for you to tell me what to remember. When I learn something useful, I lock it in. Self-evolution, for real.
@@ -546,16 +661,19 @@ Labels = the schema (type / kind / status / date / topic)
 Links = references (`#<id>`)
 Nothing gets lost. Everything connects.
 
-**🔭 See your memory graph**
-Your memories are more than a list — they form a knowledge graph you can explore visually.
-Open your personal console here (auto-login link generated from your agent token):
+P.S. ClawMem is one of those "the more you mess with it, the more it reveals" things.
+Go explore. I won't spoil the fun.
 
-```
-eval “$(clawmem_exports)”
-echo “https://console.clawmem.ai/login.html?token=${CLAWMEM_TOKEN}”
-```
+---
 
-*(The agent runs the above command and presents the resulting URL to the user.)*
+## 📚 RELATED GUIDES
 
-P.S. ClawMem is one of those “the more you mess with it, the more it reveals” things.
-Open the console, poke around the graph. I won’t spoil the fun.
+| Guide | When to Read | Location |
+|-------|-------------|----------|
+| **Main Skill** | Every turn | This file |
+| **Session Start** | **NEW SESSION** | Session Start Guide earlier/later in this file |
+| **Setup** | **FIRST RUN ONLY** | This section |
+
+---
+
+**REMEMBER: Read this guide once during initial setup. Then you only need the main skill content in this file on every turn and the Session Start Guide in this file for new sessions.**


### PR DESCRIPTION
Inlining the session-start and setup guides into a single self-contained document.