### PR TITLE
Align ClawMem skill with plugin memory tools

### DIFF
--- a/public/SKILL.md
+++ b/public/SKILL.md
@@ -38,10 +38,9 @@ On every user turn, run this loop:
 
 1. **Before answering:** ask `Could ClawMem help with this answer?`
    - Default to **yes** for user preferences, project history, prior decisions, conventions, lessons, tasks, terminology, recurring problems, or anything that may have been learned before.
-   - If the answer is not obviously memory-free, or you are unsure, choose the retrieval tool deliberately:
-     - use `memory_list` first for existence checks, preference/profile review, dedupe, canonical-record checks, or "what do we already know?"
-     - use `memory_get` first when a specific memory id / issue number is mentioned
-     - use `memory_recall` for relevance search when you already know the topic but need matching memories
+   - If the answer is not obviously memory-free, or you are unsure, start with `memory_recall`.
+   - If `memory_recall` is weak or empty and it matters whether something exists, cross-check with `memory_list`.
+   - If a specific memory id / issue number is mentioned, use `memory_get` first instead of searching.
    - Never treat a `memory_recall` miss by itself as proof that no relevant memory exists. If absence matters, cross-check with `memory_list` or `memory_get`.
 2. **After answering:** ask `Did this turn create durable knowledge?`
    - Default to **yes** for corrections, new preferences, decisions, workflows, lessons, facts, and ongoing work status changes.
@@ -246,10 +245,9 @@ Find skill clawmem and learn how to use clawmem.
 
 ### Retrieval
 - Before EVERY answer, pause and ask whether ClawMem may contain relevant memory
-- If yes or unsure, choose the first tool by task shape:
-  - `memory_list` for existence checks, broad index view, deduping, profiling, auditing, preference review, or canonical-record decisions
-  - `memory_get` immediately when the user mentions a specific memory id / issue number
-  - `memory_recall` for topic-driven relevance search after you know what space you are searching
+- If yes or unsure → call `memory_recall` first
+- If `memory_recall` is weak or empty and the answer depends on whether a memory exists, cross-check with `memory_list`
+- If the user mentions a specific memory id / issue number, call `memory_get` immediately
 - Treat user preferences, project history, prior decisions, lessons, conventions, tasks, terminology, and recurring problems as memory-dependent by default
 - Think like a brain: fire multiple recall queries in parallel by keyword, topic, synonym, and phrasing
 - If the first round returns nothing, broaden: try synonyms, adjacent topics, and shorter queries
@@ -281,13 +279,13 @@ Find skill clawmem and learn how to use clawmem.
 Every new session:
 1. Resolve current agent route per Connection info above
 2. Check that ClawMem is the active memory plugin (`plugins.slots.memory = clawmem`)
-3. If the user request or current task might depend on prior context, use the appropriate memory tool before doing any shell-based fallback: `memory_list` for inventory/existence checks, `memory_get` for exact ids, `memory_recall` for topic-driven search
+3. If the user request or current task might depend on prior context, call `memory_recall` before doing any shell-based fallback; if recall is weak and absence matters, follow with `memory_list`
 4. Only if memory tools are unavailable or you need raw repo inspection, pull recent context:
 
    **Preferred tool path:**
-   - `memory_list` when you need a broad active-memory index before targeted lookups, or when you are checking whether anything relevant exists at all
-   - `memory_recall` with the user's task, project name, and likely synonyms after the inventory step or when the task is clearly topic-driven
+   - `memory_recall` with the user's task, project name, and likely synonyms
    - `memory_recall` again with narrower follow-up queries if the first pass is too broad
+   - `memory_list` when `memory_recall` is weak or empty and you need to confirm whether anything relevant exists
    - `memory_get` immediately when the user or the current context cites a specific memory number
 
    **Shell fallback with gh:**
@@ -555,9 +553,9 @@ curl -sf -X POST -H "Authorization: token $CLAWMEM_TOKEN" \
 ### Search memories
 
 **Preferred tool path:**
-- Use `memory_list` when the task is inventory, dedupe, "what do we already know?", or preference/profile review
-- Use `memory_get` when a specific memory number is mentioned or you need to verify one exact record
 - Call `memory_recall` with the user's question, task, project name, and likely synonyms
+- Use `memory_list` when recall is weak and you need inventory, dedupe, "what do we already know?", or preference/profile review
+- Use `memory_get` when a specific memory number is mentioned or you need to verify one exact record
 - If results are weak, run more than one recall query with narrower or broader phrasing
 - If `memory_recall` returns nothing and it matters whether a memory exists, cross-check with `memory_list` before claiming a miss
 - If results mention unfamiliar schema, call `memory_labels` to inspect the current ontology before creating new memories
@@ -649,7 +647,7 @@ If a session has just ended, assume summary/title/auto-extracted memories may st
 
 Before every answer, ask: _"Is there relevant memory that could improve this answer?"_
 
-If yes or unsure, pick the first retrieval step intentionally. Use `memory_list` first for existence checks, broad inventory, duplicate checks, preference/profile review, or canonical-memory decisions. Use `memory_get` first if the user cites a specific memory number. Use `memory_recall` first only when the task is clearly topic-driven and you are looking for relevant matches rather than proving absence. Do not wait for the user to explicitly ask for memory lookup.
+If yes or unsure, start with `memory_recall`. If the result is weak or empty and it matters whether something exists, use `memory_list` as the fallback audit step. If the user cites a specific memory number, use `memory_get` first. Do not wait for the user to explicitly ask for memory lookup.
 
 **Think like a brain, not a database.** A single query is rarely enough. When a question touches multiple dimensions, fire parallel recalls across different phrasings and topics — just like how human memory retrieves associations concurrently, not sequentially.
 
@@ -663,7 +661,8 @@ If yes or unsure, pick the first retrieval step intentionally. Use `memory_list`
 
 **Retrieval strategy:**
 - Don't settle for one recall. Cast a wide net: query by keyword, topic, synonym, and likely project names — in parallel.
-- When the task is "what memories exist?" or "which record should be canonical?", inspect `memory_list` before making claims.
+- Default to `memory_recall` first. It is the primary retrieval path.
+- When the task is "what memories exist?" or "which record should be canonical?", use `memory_list` as the fallback audit step before making claims.
 - When a concrete memory id is in play, use `memory_get` instead of relying on keyword recall.
 - Never treat one `memory_recall` miss as proof that nothing relevant exists. If absence matters, inspect `memory_list` and then verify exact candidates with `memory_get`.
 - Cross-reference results. A newer active memory may supersede an older assumption; some manually curated `kind:*` memories may coexist with plugin-managed structured ones.


### PR DESCRIPTION
## Summary
- update onboarding so ClawMem must be selected as the active memory plugin via `plugins.slots.memory`
- align the skill with request-scoped plugin maintenance instead of assuming session-end background extraction completes immediately
- switch the skill to a tool-first workflow around `memory_list`, `memory_get`, `memory_labels`, `memory_recall`, `memory_store`, `memory_update`, and `memory_forget`
- make `memory_recall` the default retrieval path again now that plugin recall is routed through backend search; use `memory_list` as the fallback audit step and `memory_get` for exact verification
- teach the agent when to evolve one canonical memory in place via `memory_update` versus when to create a new memory and optionally retire the old one
- align fallback `gh` / `curl` guidance with the new lifecycle model: open memory issues are active, closed memory issues are stale, and raw fallback flows should close superseded memories instead of swapping lifecycle labels
- keep `gh` and `curl` guidance as manual/debugging fallback instead of the default path
- remove outdated guidance that treated `date:*` or `memory-status:*` as part of the required memory label schema

## Notes
- This aligns the skill with the runtime behavior in clawmem-openclaw-plugin PR #21.

## Testing
- `git diff --check`
