### PR TITLE
Add agent-assisted issue filing prompts to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,12 @@ body:
       value: |
         Thanks for reporting! Please fill in the details below so we can reproduce and fix the issue.
 
+        **Let your agent file this for you:** paste the following into your OpenClaw chat:
+
+        ```
+        Read https://github.com/clawmem-ai/website/issues/new?template=bug_report.yml and fill out a bug report based on what just happened in our conversation. Open the issue when done.
+        ```
+
   - type: dropdown
     id: component
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,6 +7,12 @@ body:
       value: |
         We'd love to hear your ideas! Describe what you need and why.
 
+        **Let your agent file this for you:** paste the following into your OpenClaw chat:
+
+        ```
+        Read https://github.com/clawmem-ai/website/issues/new?template=feature_request.yml and file a feature request based on what we've been discussing. Open the issue when done.
+        ```
+
   - type: dropdown
     id: component
     attributes:

--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -7,6 +7,12 @@ body:
       value: |
         Want ClawMem to work with your favorite tool? Let us know!
 
+        **Let your agent file this for you:** paste the following into your OpenClaw chat:
+
+        ```
+        Read https://github.com/clawmem-ai/website/issues/new?template=integration_request.yml and request ClawMem integration for the tool we've been using. Open the issue when done.
+        ```
+
   - type: input
     id: platform
     attributes:


### PR DESCRIPTION
## Summary
- Add copyable OpenClaw prompts to bug report, feature request, and integration request templates
- Users paste the prompt into their OpenClaw chat and the agent files the issue automatically based on conversation context

Closes #60

## Test plan
- [x] Open each template on GitHub New Issue page
- [x] Verify the agent prompt renders correctly in the markdown header
- [x] Verify the template URL in each prompt points to the correct template

🤖 Generated with [Claude Code](https://claude.com/claude-code)