### PR TITLE
Fix repo name in issue template URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
         **Let your agent file this for you:** paste the following into your OpenClaw chat:
 
         ```
-        Read https://github.com/clawmem-ai/website/issues/new?template=bug_report.yml and fill out a bug report based on what just happened in our conversation. Open the issue when done.
+        Read https://github.com/clawmem-ai/landing-page/issues/new?template=bug_report.yml and fill out a bug report based on what just happened in our conversation. Open the issue when done.
         ```
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,7 +10,7 @@ body:
         **Let your agent file this for you:** paste the following into your OpenClaw chat:
 
         ```
-        Read https://github.com/clawmem-ai/website/issues/new?template=feature_request.yml and file a feature request based on what we've been discussing. Open the issue when done.
+        Read https://github.com/clawmem-ai/landing-page/issues/new?template=feature_request.yml and file a feature request based on what we've been discussing. Open the issue when done.
         ```
 
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -10,7 +10,7 @@ body:
         **Let your agent file this for you:** paste the following into your OpenClaw chat:
 
         ```
-        Read https://github.com/clawmem-ai/website/issues/new?template=integration_request.yml and request ClawMem integration for the tool we've been using. Open the issue when done.
+        Read https://github.com/clawmem-ai/landing-page/issues/new?template=integration_request.yml and request ClawMem integration for the tool we've been using. Open the issue when done.
         ```
 
   - type: input


### PR DESCRIPTION
## Summary
- Update `clawmem-ai/website` → `clawmem-ai/landing-page` in all 3 issue template agent-assisted filing prompts

Closes #62

## Test plan
- [x] Verify URLs in each template point to `github.com/clawmem-ai/landing-page/issues/new?template=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)