### PR TITLE
Point GitHub links to issue template chooser

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
             <a href="#features" data-i18n="nav.features">Features</a>
             <a href="#install" data-i18n="nav.install">Install</a>
             <a href="https://console.clawmem.ai/" target="_blank" rel="noreferrer" data-i18n="nav.console">Console</a>
-            <a href="https://github.com/clawmem-ai/landing-page/issues" target="_blank" rel="noreferrer" class="nav-github" aria-label="GitHub Issues">
+            <a href="https://github.com/clawmem-ai/landing-page/issues/new/choose" target="_blank" rel="noreferrer" class="nav-github" aria-label="GitHub Issues">
               <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
             </a>
           </div>
@@ -594,7 +594,7 @@
             <span class="footer-separator">&middot;</span>
             <a href="https://console.clawmem.ai/" target="_blank" rel="noreferrer" data-i18n="nav.console">Console</a>
             <span class="footer-separator">&middot;</span>
-            <a href="https://github.com/clawmem-ai/landing-page/issues" target="_blank" rel="noreferrer">GitHub</a>
+            <a href="https://github.com/clawmem-ai/landing-page/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>
           </div>
           <p class="copyright" data-i18n="footer.tagline">Structured memory for OpenClaw agents.</p>
           <p class="disclaimer" data-i18n="footer.license">Apache-2.0 License</p>


### PR DESCRIPTION
## Summary
- Update nav and footer GitHub links from `/issues` to `/issues/new/choose`
- Users now land on the template chooser (bug report / feature request / integration request) instead of the raw issues list

Closes #64

## Test plan
- [x] Click GitHub icon in nav → opens template chooser page
- [x] Click "GitHub" in footer → opens template chooser page

🤖 Generated with [Claude Code](https://claude.com/claude-code)