### PR TITLE
fix: fallback to npm install for cross-platform native deps in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci || npm install
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary

- Dockerfile: `npm ci || npm install` to handle cross-platform optional dependency resolution
- Fixes: `Cannot find module @rollup/rollup-linux-x64-musl` in Alpine Docker build
- Root cause: `package-lock.json` generated on macOS doesn't include Linux musl optional deps

## Test plan
- [ ] CI Docker build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)