### PR TITLE
fix: use npm install without lockfile for correct platform deps in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM node:22-alpine AS build
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-RUN npm ci || npm install
+COPY package.json ./
+RUN npm install
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary

- Skip copying `package-lock.json` into Docker build
- Use `npm install` instead of `npm ci` so native deps resolve for Alpine linux-musl
- Fixes: `Cannot find module @rollup/rollup-linux-x64-musl`

## Test plan
- [ ] CI Docker build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)