### PR TITLE
fix: send analytics with credentialless fetch

### DIFF
--- a/public/scripts/analytics.js
+++ b/public/scripts/analytics.js
@@ -110,21 +110,15 @@ function sendFrontendMetric(event, props) {
   if (!analyticsEndpoint) return;
 
   const body = JSON.stringify(frontendPayload(event, props));
-  if (navigator.sendBeacon) {
-    try {
-      const blob = new Blob([body], { type: "application/json" });
-      if (navigator.sendBeacon(analyticsEndpoint, blob)) return;
-    } catch {
-      // Fall back to fetch below.
-    }
-  }
 
+  // Keep this as an explicit credentialless CORS request. Cross-origin
+  // sendBeacon can use credentialed CORS in browsers, which requires a
+  // different server contract than this public analytics endpoint needs.
   fetch(analyticsEndpoint, {
     method: "POST",
     mode: "cors",
     credentials: "omit",
     keepalive: true,
-    headers: { "Content-Type": "application/json" },
     body,
   }).catch(() => {});
 }


### PR DESCRIPTION
## Summary
- replace cross-origin analytics sendBeacon calls with explicit credentialless fetch requests
- avoid setting a JSON Content-Type header so the public analytics POST can stay a simple CORS request
- keep analytics failures non-blocking for page rendering and user interactions

## Why
Staging showed successful CORS preflight responses from gh-server, but the browser still failed analytics event requests. The landing page was using `navigator.sendBeacon()` first, which cannot explicitly set `credentials: "omit"` and can follow a different cross-origin CORS path than the fetch fallback.

## Verification
- npm run build