### PR TITLE
fix: add blog SEO head metadata

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://clawmem.ai/sitemap-index.xml

--- a/src/layouts/Landing.astro
+++ b/src/layouts/Landing.astro
@@ -2,14 +2,23 @@
 interface Props {
   title?: string;
   description?: string;
+  canonicalUrl?: string;
+  ogType?: 'website' | 'article';
+  ogDescription?: string;
+  jsonLd?: Record<string, unknown>;
 }
 
 const {
   title = 'ClawMem - Shared Memory for AI Agents',
-  description = 'ClawMem gives OpenClaw, Claude Code, Codex, and Hermes a shared memory layer that persists across sessions and agent handoffs.'
+  description = 'ClawMem gives OpenClaw, Claude Code, Codex, and Hermes a shared memory layer that persists across sessions and agent handoffs.',
+  canonicalUrl = 'https://clawmem.ai/',
+  ogType = 'website',
+  ogDescription = description,
+  jsonLd,
 } = Astro.props;
 
 const analyticsEndpoint = import.meta.env.PUBLIC_CLAWMEM_ANALYTICS_ENDPOINT ?? '';
+const safeJsonLd = jsonLd ? JSON.stringify(jsonLd).replace(/</g, '\\u003c') : '';
 ---
 
 <!doctype html>
@@ -20,9 +29,11 @@ const analyticsEndpoint = import.meta.env.PUBLIC_CLAWMEM_ANALYTICS_ENDPOINT ?? '
     <meta name="color-scheme" content="light dark" />
     <meta name="description" content={description} />
     <meta property="og:title" content={title} />
-    <meta property="og:description" content="Shared memory for AI agents. ClawMem keeps context alive across sessions, agent handoffs, and team workflows — while staying inspectable and editable." />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://clawmem.ai/" />
+    <meta property="og:description" content={ogDescription} />
+    <meta property="og:type" content={ogType} />
+    <meta property="og:url" content={canonicalUrl} />
+    <link rel="canonical" href={canonicalUrl} />
+    {jsonLd && <script type="application/ld+json" set:html={safeJsonLd} />}
     <title>{title}</title>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -13,9 +13,43 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
+
+const siteUrl = Astro.site ?? new URL('https://clawmem.ai');
+const canonicalUrl = new URL(`/blog/${post.id}/`, siteUrl).toString();
+const title = `${post.data.title} - ClawMem Blog`;
+const articleJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: post.data.title,
+  description: post.data.description,
+  url: canonicalUrl,
+  datePublished: post.data.date.toISOString(),
+  dateModified: post.data.date.toISOString(),
+  author: post.data.author
+    ? {
+        '@type': 'Person',
+        name: post.data.author,
+      }
+    : {
+        '@type': 'Organization',
+        name: 'ClawMem',
+      },
+  publisher: {
+    '@type': 'Organization',
+    name: 'ClawMem',
+    url: 'https://clawmem.ai/',
+  },
+};
 ---
 
-<Landing title={`${post.data.title} - ClawMem Blog`} description={post.data.description}>
+<Landing
+  title={title}
+  description={post.data.description}
+  canonicalUrl={canonicalUrl}
+  ogType="article"
+  ogDescription={post.data.description}
+  jsonLd={articleJsonLd}
+>
   <style>
     .post-container { max-width: 720px; margin: 0 auto; padding: 0 1.5rem; }
     article { padding: 3rem 0 4rem; }

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,9 +6,16 @@ import { getCollection } from 'astro:content';
 const posts = (await getCollection('blog')).sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf()
 );
+
+const siteUrl = Astro.site ?? new URL('https://clawmem.ai');
+const canonicalUrl = new URL('/blog/', siteUrl).toString();
 ---
 
-<Landing title="Blog - ClawMem" description="Updates, guides, and insights from the ClawMem team.">
+<Landing
+  title="Blog - ClawMem"
+  description="Updates, guides, and insights from the ClawMem team."
+  canonicalUrl={canonicalUrl}
+>
   <style>
     .blog-header { padding: 4rem 0 2.5rem; text-align: center; }
     .blog-header h1 { font-family: var(--font-display); font-size: 2.5rem; color: var(--text-primary); margin-bottom: 0.5rem; }


### PR DESCRIPTION
## Summary
- Add per-page canonical URLs and correct `og:url` handling for blog pages.
- Mark blog detail pages as `article` Open Graph type and add Article JSON-LD.
- Add a site `robots.txt` that points crawlers to the Astro sitemap index.
- Add a canonical URL to the blog index page.

## Why
The Codex blog detail page is live and present in the sitemap, but search engines were surfacing the blog index instead of the individual article. This gives crawlers cleaner page-level signals for the canonical article URL.

## Verification
- `npm run build`
- Checked built Codex blog HTML includes:
  - `<link rel="canonical" href="https://clawmem.ai/blog/codex-is-becoming-the-ai-agent-workbench-teams-actually-need/">`
  - `<meta property="og:url" content="https://clawmem.ai/blog/codex-is-becoming-the-ai-agent-workbench-teams-actually-need/">`
  - `<meta property="og:type" content="article">`
  - Article JSON-LD
- Checked `dist/robots.txt` includes the sitemap index.
