### PR TITLE
fix: point landing analytics to extension API path

### DIFF
--- a/docs/landing-page-metrics-requirement-analysis.md
+++ b/docs/landing-page-metrics-requirement-analysis.md
@@ -8,7 +8,7 @@ Use the existing gh-server Prometheus path:
 
 ```text
 clawmem.ai / blog / docs
-  -> POST https://git.clawmem.ai/api/v3/analytics/events
+  -> POST https://git.clawmem.ai/api/ext/v1/analytics/events
   -> gh-server Prometheus counter
   -> /metrics
   -> Prometheus scrape

--- a/public/scripts/analytics.js
+++ b/public/scripts/analytics.js
@@ -5,20 +5,30 @@ function ph(event, props) {
 }
 
 function defaultAnalyticsEndpoint() {
+  const analyticsPath = "/api/ext/v1/analytics/events";
   const host = window.location.hostname;
   if (host === "staging.clawmem.ai") {
-    return "https://git.staging.clawmem.ai/api/v3/analytics/events";
+    return "https://git.staging.clawmem.ai" + analyticsPath;
   }
   if (host === "clawmem.ai" || host === "www.clawmem.ai") {
-    return "https://git.clawmem.ai/api/v3/analytics/events";
+    return "https://git.clawmem.ai" + analyticsPath;
   }
   if (host === "localhost" || host === "127.0.0.1") {
-    return "http://localhost:8080/api/v3/analytics/events";
+    return "http://localhost:8080" + analyticsPath;
   }
   return "";
 }
 
-const analyticsEndpoint = window.__CLAWMEM_ANALYTICS_ENDPOINT || defaultAnalyticsEndpoint();
+function normalizeAnalyticsEndpoint(endpoint) {
+  return (endpoint || "").replace(
+    "/api/v3/analytics/events",
+    "/api/ext/v1/analytics/events"
+  );
+}
+
+const analyticsEndpoint =
+  normalizeAnalyticsEndpoint(window.__CLAWMEM_ANALYTICS_ENDPOINT) ||
+  defaultAnalyticsEndpoint();
 
 function currentPath() {
   return window.location.pathname || "/";


### PR DESCRIPTION
## Summary
- update landing analytics default endpoints from `/api/v3/analytics/events` to `/api/ext/v1/analytics/events`
- normalize any existing `PUBLIC_CLAWMEM_ANALYTICS_ENDPOINT` override that still uses the old `/api/v3` path
- update the landing metrics requirement doc to reference the extension API path

## Verification
- npm run build
- verified prod and staging analytics endpoint CORS preflight return 204 for the new `/api/ext/v1/analytics/events` path

## Notes
This matches the AGS extension API migration so landing page events can reach `gh_server_frontend_events_total` again.